### PR TITLE
Fix predis typo

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -19,7 +19,7 @@ class Configuration implements \Symfony\Component\Config\Definition\Configuratio
             ->end()
             ->children()
                 ->enumNode('driver')
-                    ->values(array('file', 'prefis', 'doctrine'))
+                    ->values(array('file', 'predis', 'doctrine'))
                 ->end()
                 ->enumNode('serializer')
                     ->defaultValue('simple')


### PR DESCRIPTION
 2fa3d50c9e58c60b29fdbfbfe6ee3eb469703632 changed predis to prefis so the driver couldn't be used.
