### PR TITLE
Fix case insensitivity in class name

### DIFF
--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -48,7 +48,7 @@
             <argument type="service" id="serializer" />
         </service>
 
-        <service id="bernard.serializer.jms" class="Bernard\Serializer\JmsSerializer" public="false">
+        <service id="bernard.serializer.jms" class="Bernard\Serializer\JMSSerializer" public="false">
             <argument type="service" id="jms_serializer" />
         </service>
 


### PR DESCRIPTION
When configuring 

```
bernard_bernard:
    serializer: jms
```

and the former incorrect spelling, you'll get a

```
  [RuntimeException]
  Case mismatch between loaded and declared class names: Bernard\Serializer\JmsSerializer vs Bernard\Serializer\JMSSerializer
```