### PR TITLE
Unable to configure listeners

### DIFF
--- a/DependencyInjection/BernardExtension.php
+++ b/DependencyInjection/BernardExtension.php
@@ -100,11 +100,9 @@ class BernardExtension extends ConfigurableExtension
     private function registerListeners(array $config, ContainerBuilder $container)
     {
         foreach ($config as $id => $params) {
-            if (empty($params)) {
-                continue;
-            }
+            if (empty($params) || (is_array($params) && !$params['enabled'])) {
+                $container->removeDefinition('bernard.listener.'.$id);
 
-            if (is_array($params) && !$params['enabled']) {
                 continue;
             }
 

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -46,16 +46,16 @@
 
         <!-- Listeners -->
 
-        <service id="bernard.listener.failure" class="Bernard\EventListener\FailureSubscriber" public="false">
+        <service id="bernard.listener.failure" class="Bernard\EventListener\FailureSubscriber">
             <argument type="service" id="bernard.queue_factory" />
             <argument /><!-- Queue name -->
         </service>
 
-        <service id="bernard.listener.logger" class="Bernard\EventListener\LoggerSubscriber" public="false">
+        <service id="bernard.listener.logger" class="Bernard\EventListener\LoggerSubscriber">
             <argument /><!-- Logger -->
         </service>
 
-        <service id="bernard.listener.error_log" class="Bernard\EventListener\ErrorLogSubscriber" public="false" />
+        <service id="bernard.listener.error_log" class="Bernard\EventListener\ErrorLogSubscriber" />
 
         <service id="bernard.listener.doctrine_schema" class="Bernard\BernardBundle\EventListener\SchemaListener" public="false" />
 

--- a/Tests/DependencyInjection/BernardExtensionTest.php
+++ b/Tests/DependencyInjection/BernardExtensionTest.php
@@ -35,6 +35,16 @@ class BernardExtensionTest extends \PHPUnit_Framework_TestCase
         $this->assertInstanceOf('Bernard\Command\ProduceCommand', $this->container->get('bernard.command.produce'));
     }
 
+    public function testListenersAreNotRegisteredByDefault()
+    {
+        $config = ['driver' => 'doctrine'];
+        $this->extension->load([$config], $this->container);
+
+        foreach (['error_log', 'logger', 'failure'] as $listener) {
+            $this->assertFalse($this->container->hasDefinition('bernard.listener.'.$listener));
+        }
+    }
+
     public function testListenersHaveSubscriberTag()
     {
         $config = [


### PR DESCRIPTION
In Symfony event listeners/subscribers are lazy loaded by `ContainerAwareEventDispatcher`, hence relevant service definitions must be public.  This PR addresses that.

