### PR TITLE
Envelope normalizer added to symfony serializer

### DIFF
--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -41,6 +41,11 @@
             <argument type="service" id="bernard.producer" />
         </service>
 
+        <!-- Normalizers -->
+        <service id="bernard.symfony.normalizer" class="Bernard\Symfony\EnvelopeNormalizer" public="false">
+            <tag name="serializer.normalizer" />
+        </service>
+
         <!-- Serializers -->
         <service id="bernard.serializer.simple" class="Bernard\Serializer\SimpleSerializer" public="false" />
 


### PR DESCRIPTION
I noticed symfony serialization was throwing errors on the 1.1.1 branch.
This is because the serialization does not know about the envelope normalizer. 
I added a service which tags the EnveloppeNormalizer as a normalizer for the symfony serializer

Tested & works on SF 2.8.3