### PR TITLE
Add commands to Command folder for registration

### DIFF
--- a/BernardBundle.php
+++ b/BernardBundle.php
@@ -4,7 +4,6 @@ namespace Bernard\BernardBundle;
 
 use Bernard\BernardBundle\DependencyInjection\Compiler\NormalizerPass;
 use Bernard\BernardBundle\DependencyInjection\Compiler\ReceiverPass;
-use Symfony\Component\Console\Application;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
@@ -16,13 +15,5 @@ class BernardBundle extends Bundle
             ->addCompilerPass(new ReceiverPass())
             ->addCompilerPass(new NormalizerPass())
         ;
-    }
-
-    public function registerCommands(Application $application)
-    {
-        parent::registerCommands($application);
-
-        $application->add($this->container->get('bernard.command.consume'));
-        $application->add($this->container->get('bernard.command.produce'));
     }
 }

--- a/Command/ConsumeCommand.php
+++ b/Command/ConsumeCommand.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Bernard\BernardBundle\Command;
+
+use Bernard\Command\ConsumeCommand as BaseConsumeCommand;
+
+class ConsumeCommand extends BaseConsumeCommand
+{
+}

--- a/Command/ProduceCommand.php
+++ b/Command/ProduceCommand.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Bernard\BernardBundle\Command;
+
+use Bernard\Command\ProduceCommand as BaseProduceCommand;
+
+class ProduceCommand extends BaseProduceCommand
+{
+}

--- a/Tests/BernardBundleTest.php
+++ b/Tests/BernardBundleTest.php
@@ -4,8 +4,6 @@ namespace Bernard\BernardBundle\Tests;
 
 use Bernard\BernardBundle\BernardBundle;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
-use Symfony\Component\Console\Application;
-use Symfony\Component\Console\Command\Command;
 
 class BernardBundleTest extends \PHPUnit_Framework_TestCase
 {
@@ -34,23 +32,5 @@ class BernardBundleTest extends \PHPUnit_Framework_TestCase
         $this->assertCount(2, $passes);
         $this->assertInstanceOf('Bernard\BernardBundle\DependencyInjection\Compiler\ReceiverPass', $passes[0]);
         $this->assertInstanceOf('Bernard\BernardBundle\DependencyInjection\Compiler\NormalizerPass', $passes[1]);
-    }
-
-    public function testCommandsAreRegistered()
-    {
-        $this->container->set('bernard.command.consume', new Command('bernard:consume'));
-        $this->container->set('bernard.command.produce', new Command('bernard:produce'));
-
-        $application = new Application();
-
-        $bundle = new BernardBundle();
-        $bundle->setContainer($this->container);
-        $bundle->registerCommands($application);
-
-        $this->assertTrue($application->has('bernard:consume'));
-        $this->assertTrue($application->has('bernard:produce'));
-
-        $this->assertTrue($application->has('bernard:debug'));
-        $this->assertInstanceOf('Bernard\BernardBundle\Command\DebugCommand', $application->get('bernard:debug'));
     }
 }


### PR DESCRIPTION
This solves https://github.com/bernardphp/BernardBundle/issues/32.

When the support for Symfony 2.3 is dropped, the registration of the commands can be done with the service container tag "console.command"