### PR TITLE
Update BernardBundle to work with latest changes on Bernard

### DIFF
--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -65,7 +65,7 @@
             <tag name="bernard.normalizer" />
         </service>
 
-        <service id="bernard.normalizer.default_message" class="Bernard\Normalizer\DefaultMessageNormalizer">
+        <service id="bernard.normalizer.plain_message" class="Bernard\Normalizer\PlainMessageNormalizer">
             <tag name="bernard.normalizer" />
         </service>
 


### PR DESCRIPTION
Bernard renamed the `DefaultNormalizer` to `PlainMessageNormalizer` with [this](https://github.com/bernardphp/bernard/commit/16f5cf141515c115e0162b9c57ee5b71aa81d52f) commit, so BernardBundle needs to be updated as well otherwise it cannot be used with latest Bernard.

*NOTE*: If we merge this one, BernardBundle will work only with Bernard versions that contain the linked commit, so most likely, we may want to release this as new BernardBundle tag and we also want to reflect it in the `composer.json` by defining the minimum bernard version needed, but I couldn't do it since at this time there is not a Bernard tag with the code that causes this problem.