### PR TITLE
Ported the removed DefaultMessageNormalizer to the BernardBundle

### DIFF
--- a/Normalizer/DefaultMessageNormalizer.php
+++ b/Normalizer/DefaultMessageNormalizer.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Bernard\BernardBundle\Normalizer;
+
+use Assert\Assertion;
+use Bernard\Message\DefaultMessage;
+use Bernard\Normalizer\PlainMessageNormalizer;
+
+class DefaultMessageNormalizer extends PlainMessageNormalizer
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function normalize($object, $format = null, array $context = [])
+    {
+        @trigger_error('The '.__CLASS__.' class is deprecated and will removed in version 3.0. Use '.PlainMessageNormalizer::class.' instead.', E_USER_DEPRECATED);
+
+        parent::normalize($object, $format, $context);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function denormalize($data, $class, $format = null, array $context = [])
+    {
+        @trigger_error('The '.__CLASS__.' class is deprecated and will removed in version 3.0. Use '.PlainMessageNormalizer::class.' instead.', E_USER_DEPRECATED);
+
+        Assertion::notEmptyKey($data, 'name');
+        Assertion::keyExists($data, 'arguments');
+        Assertion::isArray($data['arguments']);
+
+        return new DefaultMessage($data['name'], $data['arguments']);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function supportsDenormalization($data, $type, $format = null)
+    {
+        return $type === DefaultMessage::class;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function supportsNormalization($data, $format = null)
+    {
+        return $data instanceof DefaultMessage;
+    }
+}

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -69,6 +69,11 @@
             <tag name="bernard.normalizer" />
         </service>
 
+        <service id="bernard.normalizer.default_message" class="Bernard\BernardBundle\Normalizer\DefaultMessageNormalizer">
+            <tag name="bernard.normalizer" />
+        </service>
+
+
         <!-- Drivers -->
 
         <service id="bernard.driver.doctrine" class="Bernard\Driver\DoctrineDriver" public="false">


### PR DESCRIPTION
Added a bc layer for the removed `DefaultMessageNormalizer` from the bernard lib.

fixes #51 

/cc @sagikazarmark