### PR TITLE
Upgrade phpunit dependency

### DIFF
--- a/Tests/DependencyInjection/BernardExtensionTest.php
+++ b/Tests/DependencyInjection/BernardExtensionTest.php
@@ -5,7 +5,7 @@ namespace Bernard\BernardBundle\Tests\DependencyInjection;
 use Bernard\BernardBundle\DependencyInjection\BernardExtension;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 
-class BernardExtensionTest extends \PHPUnit_Framework_TestCase
+class BernardExtensionTest extends \PHPUnit\Framework\TestCase
 {
     /** @var BernardExtension */
     private $extension;
@@ -25,8 +25,8 @@ class BernardExtensionTest extends \PHPUnit_Framework_TestCase
         $this->extension->load([$config], $this->container);
 
         // Make sure we don't have a dependencies on a real driver.
-        $this->container->set('bernard.driver', $this->getMock('Bernard\Driver'));
-        $this->container->set('event_dispatcher', $this->getMock('Symfony\Component\EventDispatcher\EventDispatcherInterface'));
+        $this->container->set('bernard.driver', $this->createMock('Bernard\Driver'));
+        $this->container->set('event_dispatcher', $this->createMock('Symfony\Component\EventDispatcher\EventDispatcherInterface'));
 
         // Real services.
         $this->assertInstanceOf('Bernard\Producer', $this->container->get('bernard.producer'));

--- a/Tests/DependencyInjection/Compiler/NormalizerPassTest.php
+++ b/Tests/DependencyInjection/Compiler/NormalizerPassTest.php
@@ -5,7 +5,7 @@ namespace Bernard\BernardBundle\Tests\DependencyInjection\Compiler;
 use Bernard\BernardBundle\DependencyInjection\Compiler\NormalizerPass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 
-class NormalizerPassTest extends \PHPUnit_Framework_TestCase
+class NormalizerPassTest extends \PHPUnit\Framework\TestCase
 {
     /** @var ContainerBuilder */
     private $container;

--- a/Tests/DependencyInjection/Compiler/ReceiverPassTest.php
+++ b/Tests/DependencyInjection/Compiler/ReceiverPassTest.php
@@ -6,7 +6,7 @@ use Bernard\BernardBundle\DependencyInjection\Compiler\ReceiverPass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Reference;
 
-class ReceiverPassTest extends \PHPUnit_Framework_TestCase
+class ReceiverPassTest extends \PHPUnit\Framework\TestCase
 {
     /** @var ContainerBuilder */
     private $container;
@@ -45,10 +45,11 @@ class ReceiverPassTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($expected, $arguments[1]);
     }
 
+    /**
+     * @expectedException \RuntimeException
+     */
     public function testExceptionWhenNameAttributeIsMissing()
     {
-        $this->setExpectedException('RuntimeException');
-
         $this->container->register('test_receiver', 'stdClass')->addTag('bernard.receiver', []);
 
         $pass = new ReceiverPass();

--- a/Tests/DependencyInjection/ConfigurationTest.php
+++ b/Tests/DependencyInjection/ConfigurationTest.php
@@ -5,7 +5,7 @@ namespace Bernard\BernardBundle\Tests\DependencyInjection;
 use Bernard\BernardBundle\DependencyInjection\Configuration;
 use Symfony\Component\Config\Definition\Processor;
 
-class ConfigurationTest extends \PHPUnit_Framework_TestCase
+class ConfigurationTest extends \PHPUnit\Framework\TestCase
 {
     public function testDefaults()
     {

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     "require-dev" : {
         "symfony/console": "^2.7|^3.0",
         "symfony/finder": "^2.7|^3.0",
-        "phpunit/phpunit": "~4.0"
+        "phpunit/phpunit": "^5.5|^6.0"
     },
 
     "extra" : {


### PR DESCRIPTION
Phpunit 4.x is not supported anymore. So I've upgraded our dependency to ^5.5|^6.0 and used the forward compatibility layer (phpunit 5) for the support of namespaces.

- Upgraded phpunit
- Remove usage of deprecated function of phpunit