### PR TITLE
[SF4] Mark commands explicitly public

### DIFF
--- a/Resources/config/commands.xml
+++ b/Resources/config/commands.xml
@@ -1,18 +1,18 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <container xmlns="http://symfony.com/schema/dic/services" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
     <services>
-        <service id="bernard.command.consume" class="Bernard\Command\ConsumeCommand">
+        <service id="bernard.command.consume" class="Bernard\Command\ConsumeCommand" public="true">
             <argument type="service" id="bernard.consumer" />
             <argument type="service" id="bernard.queue_factory" />
             <tag name="console.command"/>
         </service>
 
-        <service id="bernard.command.produce" class="Bernard\Command\ProduceCommand">
+        <service id="bernard.command.produce" class="Bernard\Command\ProduceCommand" public="true">
             <argument type="service" id="bernard.producer" />
             <tag name="console.command"/>
         </service>
 
-        <service id="Bernard\BernardBundle\Command\DebugCommand" class="Bernard\BernardBundle\Command\DebugCommand">
+        <service id="Bernard\BernardBundle\Command\DebugCommand" class="Bernard\BernardBundle\Command\DebugCommand" public="true">
             <tag name="console.command"/>
         </service>
     </services>


### PR DESCRIPTION
Mark command public as all services are default private in sf4

<img width="1280" alt="screen shot 2017-11-28 at 7 55 27 pm" src="https://user-images.githubusercontent.com/1374857/33338344-1d6057d8-d476-11e7-9fae-e48edc5ca1b3.png">

Related to #59
