### PR TITLE
[SF4] Register the debug command as service

### DIFF
--- a/Command/DebugCommand.php
+++ b/Command/DebugCommand.php
@@ -2,13 +2,37 @@
 
 namespace Bernard\BernardBundle\Command;
 
+use Bernard\Router;
 use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
 use Symfony\Component\Console\Helper\Table;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
+/**
+ * @final since 2.1
+ */
 class DebugCommand extends ContainerAwareCommand
 {
+    /**
+     * @var Router
+     */
+    private $router;
+
+    public function __construct($router = null)
+    {
+        parent::__construct();
+
+        if (!$router instanceof Router) {
+            @trigger_error(sprintf('Passing a command name as the first argument of "%s" is deprecated since version symfony 3.4 and will be removed in symfony 4.0. If the command was registered by convention, make it a service instead as this will be the only supported way in bernard bundle 3.0. ', __METHOD__), E_USER_DEPRECATED);
+
+            $this->setName(null === $router ? 'bernard:debug' : $router);
+
+            return;
+        }
+
+        $this->router = $router;
+    }
+
     public function configure()
     {
         $this
@@ -19,13 +43,15 @@ class DebugCommand extends ContainerAwareCommand
 
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        $router = $this->getContainer()->get('bernard.router');
+        if (null === $this->router) {
+            $this->router = $this->getContainer()->get('bernard.router');
+        }
 
-        $r = new \ReflectionProperty($router, 'receivers');
+        $r = new \ReflectionProperty($this->router, 'receivers');
         $r->setAccessible(true);
 
         $rows = [];
-        foreach ($r->getValue($router) as $key => $val) {
+        foreach ($r->getValue($this->router) as $key => $val) {
             $rows[] = [$key, $val];
         }
 

--- a/Resources/config/commands.xml
+++ b/Resources/config/commands.xml
@@ -12,7 +12,8 @@
             <tag name="console.command" command="bernard:produce" />
         </service>
 
-        <service id="Bernard\BernardBundle\Command\DebugCommand">
+        <service class="Bernard\BernardBundle\Command\DebugCommand" id="Bernard\BernardBundle\Command\DebugCommand">
+            <argument type="service" id="bernard.router" />
             <tag name="console.command" command="bernard:debug" />
         </service>
     </services>


### PR DESCRIPTION
Because all services are default private in sf4, we register the debug command to avoid calling the container directly.

\+ A fix for for a small bc break introduced in #63 (not released yet)