### PR TITLE
Drop support for unsupported symfony versions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     "require" : {
         "php": "^5.6|^7.0",
         "bernard/bernard": "1.0.*@dev",
-        "symfony/framework-bundle": "^2.8|^3.0|^4.0"
+        "symfony/framework-bundle": "^2.8|^3.2|^4.0"
     },
 
     "require-dev" : {


### PR DESCRIPTION
Current symfony 2.8, 3.2, 3.3, 3.4 and 4.0 are the only supported versions