### PR TITLE
Lock bernard dependency before 1.0 stable BC breaks

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
 
     "require" : {
         "php": "^5.6|^7.0",
-        "bernard/bernard": "1.0.*@dev",
+        "bernard/bernard": "1.0.0-alpha9",
         "symfony/framework-bundle": "^2.8|^3.2|^4.0"
     },
 


### PR DESCRIPTION
The 1.0.0-alpha9 release will be the last release before the BC breaking changes for 1.0 stable. We will lock the dependency for bernard on that version for version 2 of the bundle. When the 1.0 stable release is ready we will adapt the BC breaks and release a v3 of the bundle with >=1.0 support for bernard